### PR TITLE
Generate servicesubscription referencenumber. fixes #138

### DIFF
--- a/users/admin.py
+++ b/users/admin.py
@@ -16,7 +16,8 @@ from .models import (
 
 class ServiceSubscriptionInline(admin.TabularInline):
     model = ServiceSubscription
-
+    exclude = ['paid_until', 'last_payment', 'reference_number', 'reminder_sent']
+    readonly_fields = ("last_payment", "reference_number")
 
 class CustomUserAdmin(UserAdmin):
     add_form = CustomUserCreationForm

--- a/users/signals.py
+++ b/users/signals.py
@@ -54,6 +54,19 @@ def user_creation(sender, instance: models.CustomUser, created, raw, **kwargs):
         logger.info("User creation done: {}".format(instance))
 
 
+@receiver(post_save, sender=models.ServiceSubscription)
+def service_subscription_create(sender, instance: models.ServiceSubscription, created, raw, **kwargs):
+    if raw:
+        return
+
+    if created:
+        if instance.reference_number is None:
+            refnum = referencenumber.generate(settings.SERVICE_INVOICE_REFERENCE_BASE + instance.id)
+            instance.reference_number = refnum
+            instance.save()
+            logger.info(f"ServiceSubscription {instance} created for user {instance.user} without reference number. Generated reference number {refnum} for it")
+
+
 @receiver(create_user)
 def send_reset_password_email(sender, instance: models.CustomUser, **kwargs):
     """

--- a/users/tests.py
+++ b/users/tests.py
@@ -1,14 +1,68 @@
 import datetime
 
+from django.contrib.auth import get_user_model
 from django.core import mail
 from django.db.utils import IntegrityError
 from django.dispatch import receiver
+from django.test import TestCase
 from django.urls import reverse
+from django.utils import timezone
 
 from rest_framework import status
 from rest_framework.test import APITestCase
 
 from . import models, signals
+
+
+class ServiceSubscriptionTests(TestCase):
+    def setUp(self):
+        # one active user, one inactive user
+        self.user = get_user_model().objects.create_customuser(
+            first_name="FirstName",
+            last_name="LastName",
+            email="user1@example.com",
+            birthday=timezone.now(),
+            municipality="City",
+            nick="user1",
+            phone="+358123123",
+        )
+        self.memberservice = models.MemberService.objects.create(
+            name="TestService",
+            cost=10,
+            days_per_payment=30,
+        )
+
+    def test_automagic_reference_number(self):
+        # create will generate reference number for us
+        ss = models.ServiceSubscription.objects.create(
+            user=self.user,
+            service=self.memberservice,
+            state=models.ServiceSubscription.OVERDUE
+        )
+        self.assertIsNotNone(ss.reference_number)
+        self.assertIn(str(ss.id), str(ss.reference_number))
+
+        # but we can still forcibly clear it
+        ss.reference_number = None
+        ss.save()
+        ss.refresh_from_db()
+        self.assertIsNone(ss.reference_number)
+
+        # and set it to what ever we want
+        ss.reference_number = 123
+        ss.save()
+        ss.refresh_from_db()
+        self.assertEqual(ss.reference_number, 123)
+
+        # and if we create one with a specific number it wont be overwritten
+        ss = models.ServiceSubscription.objects.create(
+            user=self.user,
+            service=self.memberservice,
+            state=models.ServiceSubscription.OVERDUE,
+            reference_number=999
+        )
+        self.assertIsNotNone(ss.reference_number)
+        self.assertEqual(ss.reference_number, 999)
 
 
 class UserManagerTests(APITestCase):


### PR DESCRIPTION
when new servicesubscription is created without reference number generate one automatically for it.

fixes #138 