### PR TITLE
Holvi-importer fixes

### DIFF
--- a/utils/dataimport.py
+++ b/utils/dataimport.py
@@ -253,7 +253,7 @@ class DataImport:
                 amount = int(line["Amount"])
                 peer = line["Counterparty"]
                 # holvi reference has leading zeroes, clean them up here also
-                reference = line["Reference"].strip()
+                reference = line["Reference"].strip().lstrip("0")
 
                 # Done parsing, add the transaction
 

--- a/utils/dataimport.py
+++ b/utils/dataimport.py
@@ -236,7 +236,7 @@ class DataImport:
         holvi = HolviToolbox.parse_account_statement(f)
         imported = exists = error = 0
         failedrows = []
-        for line in holvi[1:]:
+        for line in holvi[0:]:
             logger.debug(f"import_holvi - Processing line: {line}")
             try:
                 if len(line) == 0:

--- a/utils/dataimport.py
+++ b/utils/dataimport.py
@@ -236,7 +236,7 @@ class DataImport:
         holvi = HolviToolbox.parse_account_statement(f)
         imported = exists = error = 0
         failedrows = []
-        for line in holvi[0:]:
+        for line in holvi:
             logger.debug(f"import_holvi - Processing line: {line}")
             try:
                 if len(line) == 0:


### PR DESCRIPTION
Strip leading zeroes from ref.num. on Holvi-importer.
Fix holvi-importer ignoring first parsed line.

Signed-off-by: Sami Olmari <sami@olmari.fi>