### PR TITLE
Fix email encoding, fixes #289

### DIFF
--- a/emails/templates/admin/send-email.html
+++ b/emails/templates/admin/send-email.html
@@ -7,9 +7,7 @@
 
     <h1>{% trans 'Subject' %}: {{email.subject}}</h1>
     <h3>{% trans 'Body' %}:</h3>
-    <pre>
-    {% include 'mail_content_and_post.txt' %}
-    </pre>
+    <pre>{% include 'mail_content_and_post.html' %}</pre>
 
     <div class="submit-row">
       <input type="submit" class="default" value="{% trans 'Send now' %}" />

--- a/emails/templates/emails/email_detail.html
+++ b/emails/templates/emails/email_detail.html
@@ -5,9 +5,7 @@
 {% block content %}
 <div class="container">
     <h1>{{email.subject}}</h1>
-    <pre>
-    {% include 'mail_content_and_post.txt' %}
-    </pre>
+    <pre>{% include 'mail_content_and_post.html' %}</pre>
 </div>
 {% endblock %}
 

--- a/emails/templates/mail_content_and_post.html
+++ b/emails/templates/mail_content_and_post.html
@@ -1,0 +1,5 @@
+{# Preview and web version of the email #}
+{% load i18n %}{{ email.content }}
+
+---
+{% blocktrans %}You are receiving this email because you are registered member of {{ SITENAME }}{% endblocktrans %}

--- a/emails/templates/mail_content_and_post.txt
+++ b/emails/templates/mail_content_and_post.txt
@@ -1,5 +1,5 @@
 {# The real content of the email, first the content and then the "post" stuff like, why this email was sent #}
-{% load i18n %}{{ email.content }}
+{% load i18n %}{% autoescape off %}{{ email.content }}
 
 ---
-{% blocktrans %}You are receiving this email because you are registered member of {{ SITENAME }}{% endblocktrans %}
+{% blocktrans %}You are receiving this email because you are registered member of {{ SITENAME }}{% endblocktrans %}{% endautoescape %}

--- a/emails/tests.py
+++ b/emails/tests.py
@@ -15,8 +15,15 @@ class EmailAdminTestCase(TestCase):
 
     def setUp(self):
         self.client = Client()
-        self.email = Email.objects.create(subject="Test email 1", content="Test message 1\nWith\nNewlines\n and special characters öä'\"&<>\n\nand utf-8 test string ᚻᛖ ᚳᚹᚫᚦ ᚦᚫᛏ ᚻᛖ ᛒᚢᛞᛖ ᚩᚾ ᚦᚫᛗ ᛚᚪᚾᛞᛖ ᚾᚩᚱᚦᚹᛖᚪᚱᛞᚢᛗ ᚹᛁᚦ ᚦᚪ ᚹᛖᛥᚫ")
-        self.email_sent = Email.objects.create(subject="Test email 1", content="Test message 1\nWith\nNewlines", sent=timezone.now())
+        self.email = Email.objects.create(
+            subject="Test email 1",
+            content="Test message 1\nWith\nNewlines\n and special characters öä'\"&<>\n\nand utf-8 test string ᚻᛖ ᚳᚹᚫᚦ ᚦᚫᛏ ᚻᛖ ᛒᚢᛞᛖ ᚩᚾ ᚦᚫᛗ ᛚᚪᚾᛞᛖ ᚾᚩᚱᚦᚹᛖᚪᚱᛞᚢᛗ ᚹᛁᚦ ᚦᚪ ᚹᛖᛥᚫ",
+        )
+        self.email_sent = Email.objects.create(
+            subject="Test email 1",
+            content="Test message 1\nWith\nNewlines",
+            sent=timezone.now(),
+        )
         self.user = get_user_model().objects.create_superuser(
             email="testsuper@example.com",
             first_name="test",
@@ -27,21 +34,21 @@ class EmailAdminTestCase(TestCase):
         self.client.force_login(self.user)
 
     def test_listing_actions(self):
-        url = reverse('admin:emails_email_changelist')
+        url = reverse("admin:emails_email_changelist")
         response = self.client.get(url)
-        self.assertContains(response, reverse('admin:email-send', args=[self.email.pk]))
-        self.assertContains(response, '/email/' + self.email_sent.get_url())
+        self.assertContains(response, reverse("admin:email-send", args=[self.email.pk]))
+        self.assertContains(response, "/email/" + self.email_sent.get_url())
 
     def test_send_preview(self):
-        url = reverse('admin:email-send', args=[self.email.pk])
+        url = reverse("admin:email-send", args=[self.email.pk])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, html.escape(self.email.content))
 
     def test_sending(self):
         self.assertIsNone(self.email.sent)
-        url = reverse('admin:email-send', args=[self.email.pk])
-        data = {'action': 'email-send'}
+        url = reverse("admin:email-send", args=[self.email.pk])
+        data = {"action": "email-send"}
         response = self.client.post(url, data)
         self.assertEqual(response.status_code, 302)
         self.email.refresh_from_db()
@@ -50,7 +57,7 @@ class EmailAdminTestCase(TestCase):
         self.assertIsNotNone(self.email.sent)
 
         # check that the view in browser is accessible
-        url = '/email/'+self.email.get_url()
+        url = "/email/" + self.email.get_url()
         preview = self.client.get(url)
         self.assertContains(preview, html.escape(self.email.content))
 
@@ -63,35 +70,40 @@ class EmailAdminTestCase(TestCase):
 class EmailTestCase(TestCase):
     def setUp(self):
         # few test emails
-        self.email1 = Email.objects.create(subject="Test email 1", content="Test message 1\nWith\nNewlines\n and special characters öä'\"&<>\n\nand utf-8 test string ᚻᛖ ᚳᚹᚫᚦ ᚦᚫᛏ ᚻᛖ ᛒᚢᛞᛖ ᚩᚾ ᚦᚫᛗ ᛚᚪᚾᛞᛖ ᚾᚩᚱᚦᚹᛖᚪᚱᛞᚢᛗ ᚹᛁᚦ ᚦᚪ ᚹᛖᛥᚫ")
+        self.email1 = Email.objects.create(
+            subject="Test email 1",
+            content="Test message 1\nWith\nNewlines\n and special characters öä'\"&<>\n\nand utf-8 test string ᚻᛖ ᚳᚹᚫᚦ ᚦᚫᛏ ᚻᛖ ᛒᚢᛞᛖ ᚩᚾ ᚦᚫᛗ ᛚᚪᚾᛞᛖ ᚾᚩᚱᚦᚹᛖᚪᚱᛞᚢᛗ ᚹᛁᚦ ᚦᚪ ᚹᛖᛥᚫ",
+        )
 
         # one active user, one inactive user
-        self.user1 = get_user_model().objects.create_customuser(first_name="FirstName",
-                                                                last_name="LastName",
-                                                                email="user1@example.com",
-                                                                birthday=timezone.now(),
-                                                                municipality="City",
-                                                                nick="user1",
-                                                                phone="+358123123",
-                                                                )
+        self.user1 = get_user_model().objects.create_customuser(
+            first_name="FirstName",
+            last_name="LastName",
+            email="user1@example.com",
+            birthday=timezone.now(),
+            municipality="City",
+            nick="user1",
+            phone="+358123123",
+        )
         self.user1.is_active = True
         self.user1.save()
-        self.user2 = get_user_model().objects.create_customuser(first_name="Another",
-                                                                last_name="User",
-                                                                email="user2@example.com",
-                                                                birthday=timezone.now(),
-                                                                municipality="City",
-                                                                nick="user2",
-                                                                phone="+358321321",
-                                                                )
+        self.user2 = get_user_model().objects.create_customuser(
+            first_name="Another",
+            last_name="User",
+            email="user2@example.com",
+            birthday=timezone.now(),
+            municipality="City",
+            nick="user2",
+            phone="+358321321",
+        )
         self.user2.is_active = False
         self.user2.save()
 
     def test_email_object(self):
         email = Email.objects.get(subject="Test email 1")
-        self.assertEqual(email.slug, 'test-email-1')
+        self.assertEqual(email.slug, "test-email-1")
         self.assertIsNone(email.sent)
-        self.assertEqual(email.get_epoch(), '000')
+        self.assertEqual(email.get_epoch(), "000")
 
     def test_queue_and_send(self):
         # queue our test message to queryset of recipients

--- a/emails/tests.py
+++ b/emails/tests.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import get_user_model
 from django.test import Client, TestCase
 from django.urls import reverse
-from django.utils import timezone
+from django.utils import html, timezone
 
 from mailer.models import Message
 
@@ -15,7 +15,7 @@ class EmailAdminTestCase(TestCase):
 
     def setUp(self):
         self.client = Client()
-        self.email = Email.objects.create(subject="Test email 1", content="Test message 1\nWith\nNewlines")
+        self.email = Email.objects.create(subject="Test email 1", content="Test message 1\nWith\nNewlines\n and special characters öä'\"&<>\n\nand utf-8 test string ᚻᛖ ᚳᚹᚫᚦ ᚦᚫᛏ ᚻᛖ ᛒᚢᛞᛖ ᚩᚾ ᚦᚫᛗ ᛚᚪᚾᛞᛖ ᚾᚩᚱᚦᚹᛖᚪᚱᛞᚢᛗ ᚹᛁᚦ ᚦᚪ ᚹᛖᛥᚫ")
         self.email_sent = Email.objects.create(subject="Test email 1", content="Test message 1\nWith\nNewlines", sent=timezone.now())
         self.user = get_user_model().objects.create_superuser(
             email="testsuper@example.com",
@@ -36,7 +36,7 @@ class EmailAdminTestCase(TestCase):
         url = reverse('admin:email-send', args=[self.email.pk])
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, self.email.content)
+        self.assertContains(response, html.escape(self.email.content))
 
     def test_sending(self):
         self.assertIsNone(self.email.sent)
@@ -52,7 +52,7 @@ class EmailAdminTestCase(TestCase):
         # check that the view in browser is accessible
         url = '/email/'+self.email.get_url()
         preview = self.client.get(url)
-        self.assertContains(preview, self.email.content)
+        self.assertContains(preview, html.escape(self.email.content))
 
         # and check that non auth users cannot view it
         self.client.logout()
@@ -63,7 +63,7 @@ class EmailAdminTestCase(TestCase):
 class EmailTestCase(TestCase):
     def setUp(self):
         # few test emails
-        self.email1 = Email.objects.create(subject="Test email 1", content="Test message 1\nWith\nNewlines")
+        self.email1 = Email.objects.create(subject="Test email 1", content="Test message 1\nWith\nNewlines\n and special characters öä'\"&<>\n\nand utf-8 test string ᚻᛖ ᚳᚹᚫᚦ ᚦᚫᛏ ᚻᛖ ᛒᚢᛞᛖ ᚩᚾ ᚦᚫᛗ ᛚᚪᚾᛞᛖ ᚾᚩᚱᚦᚹᛖᚪᚱᛞᚢᛗ ᚹᛁᚦ ᚦᚪ ᚹᛖᛥᚫ")
 
         # one active user, one inactive user
         self.user1 = get_user_model().objects.create_customuser(first_name="FirstName",


### PR DESCRIPTION
Better test case and use different templates for rendering the txt and html versions of the email content