### PR TITLE
Subscription information in accessdenied email, fixes #291

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -210,7 +210,13 @@ class TestAccess(APITestCase):
         self.assertIn(
             "Käyttäjätililläsi ei ole tällähetkellä pääsyä oveen.",
             mail.outbox[0].body,
-            "failure notification",
+            "failure notification intro text",
+        )
+        # list of services in the mail
+        self.assertIn(
+            f"{self.fail_user.servicesubscription_set.first().service.name}: {self.fail_user.servicesubscription_set.first().state}",
+            mail.outbox[0].body,
+            "first ss state",
         )
         self.assertIn(settings.SITE_URL, mail.outbox[0].body, "siteurl")
         self.assertEqual(response.status_code, 481)

--- a/users/signals.py
+++ b/users/signals.py
@@ -250,6 +250,7 @@ def notify_user_door_access_denied(sender, user: models.CustomUser, method, **kw
     context = {
         "user": user,
         "settings": settings,
+        "method": method,
     }
     translation.activate(user.language)
     subject = _("Door access denied")

--- a/users/templates/mail/door_access_denied.txt
+++ b/users/templates/mail/door_access_denied.txt
@@ -1,7 +1,7 @@
 {% extends 'mail/email_base.txt' %}
 {% load i18n %}
 {% block content %}
-{% blocktrans with first_name=user.first_name siteurl=settings.SITE_URL wikiurl=settings.MEMBERS_GUIDE_URL %}
+{% blocktrans with first_name=user.first_name method=method siteurl=settings.SITE_URL wikiurl=settings.MEMBERS_GUIDE_URL %}
 Hi {{first_name}}!
 
 We noticed that you tried to access the door by using {{method}} to open it.
@@ -12,4 +12,11 @@ Please check your access status by logging into the member service.
 
 {{siteurl}}
 {% endblocktrans %}
+
+{% trans "Your services status:" %}
+{% for subscription in user.servicesubscription_set.all %}
+{{subscription.service.name}}: {{subscription.state}}
+{% empty %}
+{% trans "No services" %}
+{% endfor %}
 {% endblock %}


### PR DESCRIPTION
These templates require a full rewrite anyway with #172 so just add the information at the end for now.

