### PR TITLE
Cleanup extra staff actions in user views

### DIFF
--- a/www/templates/www/user.html
+++ b/www/templates/www/user.html
@@ -7,13 +7,6 @@
     {% trans 'User data for' %} {{ userdetails.first_name }} {{ userdetails.last_name }}
   </h1>
 
-  {% if user.is_staff %}
-    <p>
-      <a href="{% url 'updateuser' userdetails.id %}">{% trans "Update user's data" %}</a> |
-      <a href="{% url 'admin:users_customuser_change' userdetails.id %}">{% trans "View in admin" %}</a>
-    </p>
-  {% endif %}
-
   <table class="table">
     <tr>
       <td>{% trans 'Name' %}</td>

--- a/www/templates/www/users.html
+++ b/www/templates/www/users.html
@@ -3,7 +3,7 @@
 {% load humanize %}
 {% block content %}
 <h2>
-  User list
+  User list <a class="small" href="{% url 'users/create' %}">{% trans 'Create new user' %}</a>
 </h2>
 <table class="table table-striped table-responsive-sm">
   <thead class="thead-light">

--- a/www/templates/www/users.html
+++ b/www/templates/www/users.html
@@ -5,11 +5,6 @@
 <h2>
   User list
 </h2>
-<ul>
-  <li class="nav-item">
-    <a class="nav-link" href="{% url 'users/create' %}">{% trans 'Create new user' %}</a>
-  </li>
-</ul>
 <table class="table table-striped table-responsive-sm">
   <thead class="thead-light">
     <tr>


### PR DESCRIPTION
* hide admin actions from userdetails page, these can be accessed from users listing
* remove create new user from users list, this link is way too easy to click on mobile and all user creation should anyway go trough the regular flow