### PR TITLE
Feat/report userdata on api failed dooropen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Changelog
 
-* [pull] master from TampereHacklab:master. PR [#54](https://github.com/vaasahacklab/mulysa/pull/54) by [@pull[bot]](https://github.com/apps/pull).
 * Subscription information in accessdenied email, fixes #291. PR [#293](https://github.com/TampereHacklab/mulysa/pull/293) by [@tswfi](https://github.com/tswfi).
 * Fix email encoding, fixes #289. PR [#290](https://github.com/TampereHacklab/mulysa/pull/290) by [@tswfi](https://github.com/tswfi).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+* [pull] master from TampereHacklab:master. PR [#54](https://github.com/vaasahacklab/mulysa/pull/54) by [@pull[bot]](https://github.com/apps/pull).
 * Subscription information in accessdenied email, fixes #291. PR [#293](https://github.com/TampereHacklab/mulysa/pull/293) by [@tswfi](https://github.com/tswfi).
 * Fix email encoding, fixes #289. PR [#290](https://github.com/TampereHacklab/mulysa/pull/290) by [@tswfi](https://github.com/tswfi).
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ API will return these responses on certain error conditions:
  - 404 when deviceid isn't found
  - 480 when phone number/NFC id/mxid is not found at all
  - 481 when phone number/NFC id/mxid is found within member but has no access rights
+   - 481 responses will also contain basic user data for example executing proper procedures and admin logs
 
 There are two example implementations for esp32 based access readers that can be found here:
 

--- a/README.md
+++ b/README.md
@@ -127,8 +127,7 @@ API will return these responses on certain error conditions:
  - 400 when query has invalid content
  - 404 when deviceid isn't found
  - 480 when phone number/NFC id/mxid is not found at all
- - 481 when phone number/NFC id/mxid is found within member but has no access rights
-   - 481 responses will also contain basic user data for example executing proper procedures and admin logs
+ - 481 when phone number/NFC id/mxid is found within member but has no access rights, response will also contain basic user data for example executing proper procedures and admin logs
 
 There are two example implementations for esp32 based access readers that can be found here:
 

--- a/api/tests.py
+++ b/api/tests.py
@@ -41,7 +41,7 @@ class TestLogging(APITestCase):
         # check that we have a drf-tracking log entry
         self.assertEqual(APIRequestLog.objects.count(), 1)
         self.assertIn(self.ok_user.phone, APIRequestLog.objects.first().data)
-        self.assertEqual(APIRequestLog.objects.first().response, "")
+        self.assertNotEqual(APIRequestLog.objects.first().response, "")
 
     def tearDown(self):
         CustomUser.objects.all().delete()

--- a/api/tests.py
+++ b/api/tests.py
@@ -37,11 +37,10 @@ class TestLogging(APITestCase):
         response = self.client.post(url, data)
         # someone wanted these strange status_codes :)
         self.assertEqual(response.status_code, 481)
-
         # check that we have a drf-tracking log entry
         self.assertEqual(APIRequestLog.objects.count(), 1)
         self.assertIn(self.ok_user.phone, APIRequestLog.objects.first().data)
-        self.assertNotEqual(APIRequestLog.objects.first().response, "")
+        self.assertIn(self.ok_user.email, APIRequestLog.objects.first().response)
 
     def tearDown(self):
         CustomUser.objects.all().delete()

--- a/api/views.py
+++ b/api/views.py
@@ -99,7 +99,8 @@ class AccessViewSet(LoggingMixin, mixins.ListModelMixin, viewsets.GenericViewSet
         if not user.has_door_access():
             user.log("Door access denied with phone")
             door_access_denied.send(sender=self.__class__, user=user, method="phone")
-            return Response(status=481)
+            outserializer = UserAccessSerializer(user)
+            return Response(outserializer.data, status=481)
 
         user.log("Door opened with phone")
         outserializer = UserAccessSerializer(user)

--- a/api/views.py
+++ b/api/views.py
@@ -174,6 +174,10 @@ class AccessViewSet(LoggingMixin, mixins.ListModelMixin, viewsets.GenericViewSet
             outserializer = UserAccessSerializer(user)
             return Response(outserializer.data)
 
+        if response_status == 481:
+            outserializer = UserAccessSerializer(user)
+            return Response(outserializer.data, status=response_status)
+
         return Response(status=response_status)
 
     @action(detail=False, methods=["post"], throttle_classes=[VerySlowThrottle])

--- a/api/views.py
+++ b/api/views.py
@@ -216,6 +216,10 @@ class AccessViewSet(LoggingMixin, mixins.ListModelMixin, viewsets.GenericViewSet
             outserializer = UserAccessSerializer(user)
             return Response(outserializer.data)
 
+        if response_status == 481:
+            outserializer = UserAccessSerializer(user)
+            return Response(outserializer.data, status=response_status)
+
         return Response(status=response_status)
 
     def list(self, request):


### PR DESCRIPTION
Report back userdata on query-API on known member accessing door but denied (481) so automations that supports can handle situation better (logging and administrative reports etc).