### PR TITLE
reintroduce the updateuser functionality for admins

### DIFF
--- a/www/templates/www/users.html
+++ b/www/templates/www/users.html
@@ -1,23 +1,27 @@
 {% extends "www/base.html" %}
 {% load i18n %}
 {% load humanize %}
+{% load bootstrap4 %}
 {% block content %}
 <h2>
-  User list <a class="small" href="{% url 'users/create' %}">{% trans 'Create new user' %}</a>
+  {% trans 'User list' %} <a class="small" href="{% url 'users/create' %}">{% trans 'Create new user' %}</a>
 </h2>
+
+{% bootstrap_messages %}
+
 <table class="table table-striped table-responsive-sm">
   <thead class="thead-light">
     <tr>
-      <th>Name</th>
-      <th>Nick</th>
-      <th>Email</th>
-      <th>Phone</th>
+      <th>{% trans 'Name' %}</th>
+      <th>{% trans 'Nick' %}</th>
+      <th>{% trans 'Email' %}</th>
+      <th>{% trans 'Phone' %}</th>
       {% for service in services %}
       <th>{{ service.name }}</th>
       {% endfor %}
-      <th>Extra services</th>
-      <th>Last login</th>
-      <th>Management</th>
+      <th>{% trans 'Extra services' %}</th>
+      <th>{% trans 'Last login' %}</th>
+      <th>{% trans 'Management' %}</th>
     </tr>
   </thead>
   {% for user in users %}
@@ -55,9 +59,18 @@
     </td>
     <td>{{ user.last_login|naturaltime }}</td>
     <td>
-      <a class="btn btn-primary btn-sm" href="{% url 'usersettings' user.id %}">Edit</a>
+      <a class="btn btn-primary btn-sm" href="{% url 'usersettings' user.id %}">{% trans 'Edit' %}</a>
+      <form action="{% url 'updateuser' %}" method="post" class="form-inline">
+        {% csrf_token %}
+        <input type="hidden" name="userid" value="{{user.id}}" />
+        <input
+        type="submit"
+        class="btn btn-secondary btn-sm"
+        value="{% trans 'Recalc' %}"
+      />
+      </form>
       {% if request.user.is_superuser %}
-      <a class="btn btn-danger btn-sm" href="{% url 'admin:users_customuser_change' user.id %}">View in admin</a>
+      <a class="btn btn-danger btn-sm" href="{% url 'admin:users_customuser_change' user.id %}">{% trans 'View in admin' %}</a>
       {% endif %}
     </td>
   </tr>

--- a/www/urls.py
+++ b/www/urls.py
@@ -26,7 +26,7 @@ urlpatterns = [
         views.custominvoice_action,
         name="custominvoice_action",
     ),
-    path("updateuser/<int:id>/", views.updateuser, name="updateuser"),
+    path("updateuser", views.updateuser, name="updateuser"),
     path("applications", views.applications, name="applications"),
     path(
         "applications/<int:application_id>/<str:operation>",

--- a/www/views.py
+++ b/www/views.py
@@ -495,20 +495,12 @@ def banktransaction_view(request, banktransactionid):
 
 @login_required
 @staff_member_required
-def updateuser(request, id):
-    user = CustomUser.objects.get(id=id)
-
-    # First, generate any missing ref numbers
-    subscriptions = ServiceSubscription.objects.filter(user=user)
-    for subscription in subscriptions:
-        if not subscription.reference_number:
-            subscription.reference_number = referencenumber.generate(
-                settings.SERVICE_INVOICE_REFERENCE_BASE + subscription.id
-            )
-            subscription.save()
-
-    BusinessLogic.updateuser(user)
-    return userdetails(request, id)
+def updateuser(request):
+    if request.method == "POST":
+        user = get_object_or_404(CustomUser, id=request.POST["userid"])
+        BusinessLogic.updateuser(user)
+        messages.success(request, _(f"Updateuser ran for user {user}"))
+    return HttpResponseRedirect(reverse("users"))
 
 
 @login_required


### PR DESCRIPTION
this is needed as the updateusers does not always see what happened.

basically clicking on the button runs businesslogic.updateuser for that user (which it should have done automatically)

Until the automation gets fixed for good lets leave the button here.