### PR TITLE
Bug/overdue allow dooraccess

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -16,6 +16,8 @@ from utils.phonenumber import normalize_number
 from .models import AccessDevice, DeviceAccessLogEntry
 from users.signals import door_access_denied
 
+from django.db.models import Q
+
 logger = logging.getLogger(__name__)
 
 

--- a/api/views.py
+++ b/api/views.py
@@ -108,10 +108,20 @@ class AccessViewSet(LoggingMixin, mixins.ListModelMixin, viewsets.GenericViewSet
 
         # collect list of all users that have door access
         users_with_door_access = []
+
+        # Members with active door access
         for ss in (
             ServiceSubscription.objects.select_related("user")
             .filter(service=drfx_settings.DEFAULT_ACCOUNT_SERVICE)
             .filter(state=ServiceSubscription.ACTIVE)
+        ):
+            users_with_door_access.append(ss.user)
+
+        # Members with overdue door access
+        for ss in (
+            ServiceSubscription.objects.select_related("user")
+            .filter(service=drfx_settings.DEFAULT_ACCOUNT_SERVICE)
+            .filter(state=ServiceSubscription.OVERDUE)
         ):
             users_with_door_access.append(ss.user)
 

--- a/api/views.py
+++ b/api/views.py
@@ -109,22 +109,13 @@ class AccessViewSet(LoggingMixin, mixins.ListModelMixin, viewsets.GenericViewSet
         # collect list of all users that have door access
         users_with_door_access = []
 
-        # Members with active door access
+        # Members with active or overdue door access
         for ss in (
             ServiceSubscription.objects.select_related("user")
             .filter(service=drfx_settings.DEFAULT_ACCOUNT_SERVICE)
-            .filter(state=ServiceSubscription.ACTIVE)
+            .filter(Q(state=ServiceSubscription.ACTIVE) | Q(state=ServiceSubscription.OVERDUE))
         ):
             users_with_door_access.append(ss.user)
-
-        # Members with overdue door access
-        for ss in (
-            ServiceSubscription.objects.select_related("user")
-            .filter(service=drfx_settings.DEFAULT_ACCOUNT_SERVICE)
-            .filter(state=ServiceSubscription.OVERDUE)
-        ):
-            users_with_door_access.append(ss.user)
-
         # and output it
         outserializer = UserAccessSerializer(users_with_door_access, many=True)
         return Response(outserializer.data)

--- a/users/models.py
+++ b/users/models.py
@@ -233,7 +233,7 @@ class CustomUser(AbstractUser):
             subscription = self.servicesubscription_set.get(
                 service=drfx_settings.DEFAULT_ACCOUNT_SERVICE
             )
-            if subscription.state == ServiceSubscription.ACTIVE:
+            if subscription.state == ServiceSubscription.ACTIVE or subscription.state == ServiceSubscription.OVERDUE:
                 return True
         except Exception:
             pass


### PR DESCRIPTION
Fix "tilamaksu" overdue member to be allowed access door. Changes both POST and GET methods of door API call results:

POST calls, change is in "MonthlyOverdue" result
```
{"email":"1@example.tld","first_name":"NotMember","last_name":"NotMonthly","nick":null,"phone":"+358001"}
Response code: 481

{"email":"2@example.tld","first_name":"Member","last_name":"NotMonthly","nick":null,"phone":"+358002"}
Response code: 481

{"email":"3@example.tld","first_name":"Member","last_name":"MonthlyOverdue","nick":null,"phone":"+358003"}
Response code: 200

{"email":"4@example.tld","first_name":"Member","last_name":"Monthly","nick":null,"phone":"+358004"}
Response code: 200

{"email":"5@example.tld","first_name":"Member","last_name":"MonthlySuspended","nick":null,"phone":"+358005"}
Response code: 481

```

GET method also includes MonthlyOverdue member:
```
[{"email":"4@example.tld","first_name":"Member","last_name":"Monthly","nick":null,"phone":"+358004"},{"email":"3@example.tld","first_name":"Member","last_name":"MonthlyOverdue","nick":null,"phone":"+358003"}]
Response code: 200
```