### PR TITLE
nginx forwarded-proto: pass the forwarded-proto header that traefik set

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -10,7 +10,7 @@ server {
         proxy_pass http://mulysa;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
         proxy_redirect off;
     }
     location /static/ {


### PR DESCRIPTION
ok, so this fixes the email reset link to be https

BUT it does not seem to fix the "token already used" problem with clicking the link in gmail...