### PR TITLE
docs: remove old prerequisite list

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,6 @@ Find a way to install the software on this list (click the links to find install
 * [MySQL C API (libmysqlclient)](https://dev.mysql.com/downloads/c-api/)
 * [pipenv](https://github.com/pypa/pipenv)
 
-Optional:
-
-* python 3.7
-* pipenv from here: https://github.com/pypa/pipenv
-
 When you have the prerequisites installed, run these commands:
 
 ```bash


### PR DESCRIPTION
This section got left in in my previous PR by accident. 

One thing I'm unsure of is what Python version should be listed as a prerequisite. 