### PR TITLE
Fix transaction graph grouping by summing the data

### DIFF
--- a/users/tests.py
+++ b/users/tests.py
@@ -521,10 +521,20 @@ class BankAggreagetApiTests(APITestCase):
         response = self.client.get(url, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 10)
+
+        # check first day data
         firstDay = response.data[0]
         self.assertEqual(firstDay["withdrawals"], -55)
+        self.assertEqual(firstDay["deposits"], 55)
         self.assertEqual(firstDay["deposits"] + firstDay["withdrawals"], 0)
         self.assertEqual(firstDay["aggregatedate"], "2022-01-01")
+
+        # last day data is similar
+        lastDay = response.data[-1]
+        self.assertEqual(lastDay["withdrawals"], -55)
+        self.assertEqual(lastDay["deposits"], 55)
+        self.assertEqual(lastDay["deposits"] + lastDay["withdrawals"], 0)
+        self.assertEqual(lastDay["aggregatedate"], "2022-01-10")
 
     def test_get_banktransactionaggregatedata_filtered(self):
         """
@@ -540,6 +550,7 @@ class BankAggreagetApiTests(APITestCase):
         self.assertEqual(len(response.data), 1)
         firstDay = response.data[0]
         self.assertEqual(firstDay["withdrawals"], -55)
+        self.assertEqual(firstDay["deposits"], 55)
         self.assertEqual(firstDay["deposits"] + firstDay["withdrawals"], 0)
         self.assertEqual(firstDay["aggregatedate"], "2022-01-01")
 

--- a/www/static/www/graphs.js
+++ b/www/static/www/graphs.js
@@ -1,94 +1,131 @@
 async function renderTransactionsGraph() {
+  // for now default to fetching data 1 year back from now
+  // this fetches the data aggregated per day
+  let startDate = new Date();
+  startDate.setFullYear(startDate.getFullYear() - 1);
+  const queryParams = {
+    date__gte: startDate.toISOString().slice(0, 10),
+  };
+  const searchParams = new URLSearchParams(queryParams);
+  const response = await fetch(
+    "/api/v1/banktransactionaggregate/?" + searchParams.toString()
+  );
 
-    const container = document.getElementById('transactionsGraphContainer');
-    const graphcanvas = container.querySelector("#transactionsGraph");
+  const data = await response.json();
 
-    const Groupings = {
-        'day': gettext('daily'),
-        'week': gettext('weekly'),
-        'month': gettext('monthly'),
-        'year': gettext('yearly')
-    }
-    var buttonContainer = document.createElement("div");
-    buttonContainer.className = "transactionGraphGroupingContainer";
-    buttonContainer.onclick = function (event) {
-        event.stopPropagation();
-        event.preventDefault();
-        var buttons = buttonContainer.querySelectorAll('a.btn');
-        buttons.forEach(function(button) {
-            button.classList.remove('btn-primary');
-            button.classList.add('btn-secondary');
-        });
-        grouping = event.target.dataset.grouping;
-        chart.options.scales.x.time.unit = event.target.dataset.grouping;
-        chart.options.scales.x.time.round = event.target.dataset.grouping;
-        chart.update();
-        event.target.classList.remove('btn-secondary');
-        event.target.classList.add('btn-primary');
-    };
-    container.prepend(buttonContainer);
-    Object.entries(Groupings).forEach(([key, value]) => {
-        var btn = document.createElement("a");
-        btn.className = "btn btn-secondary mr-2 transactionGroupingButton";
-        btn.id = "transactionGraphGrouping_" + key;
-        btn.dataset.grouping = key;
-        btn.innerText = value;
-        buttonContainer.append(btn);
-    });
-    // default to month
-    container.querySelector('#transactionGraphGrouping_month').classList.remove('btn-secondary');
-    container.querySelector('#transactionGraphGrouping_month').classList.add('btn-primary');
-
-    // for now default to fetching data 1 year back from now
-    let startDate = new Date();
-    startDate.setFullYear(startDate.getFullYear() - 1);
-    const queryParams = {
-        date__gte: startDate.toISOString().slice(0, 10),
-    };
-    const searchParams = new URLSearchParams(queryParams);
-    const response = await fetch("/api/v1/banktransactionaggregate/?" + searchParams.toString());
-    const data = await response.json();
-    let labels = [];
+  // helper for building grouped data by month / year from the daily aggregate data
+  // TODO: add back the week grouping :)
+  let buildGroupedDataGraphData = function(data, grouping) {
+    let labels = new Set();
     let deposits = [];
     let withdrawals = [];
-    for (i = 0; i < data.length; i++) {
-        labels.push(data[i].aggregatedate);
-        deposits.push(data[i].deposits);
-        withdrawals.push(data[i].withdrawals);
-    }
 
-    // render the chart
-    chart = new Chart(graphcanvas, {
-        type: "bar",
-        data: {
-            labels: labels,
-            datasets: [
-                {
-                    label: gettext('Deposits'),
-                    data: deposits,
-                    backgroundColor: "#227D7D"
-                },
-                {
-                    label: gettext('Withdrawals'),
-                    data: withdrawals,
-                    backgroundColor: "#D13838"
-                },
-            ],
-        },
-        options: {
-            legend: { display: true },
-            scales: {
-                x: {
-                    type: 'time',
-                    time: {
-                        unit: 'month',
-                        round: 'month'
-                    },
-                    stacked: true,
-                },
-            },
-        },
+    // default to full date format 2022-01-01
+    let l = 10;
+
+    data.forEach(item => {
+      if (grouping === "month") {
+        l = 7; // 2022-01
+      }
+      if (grouping === "year") {
+        l = 4; // 2022
+      }
+      const label = item.aggregatedate.slice(0, l);
+      labels.add(label);
     });
 
+    labels.forEach(label => {
+      deposits.push(
+        data
+          .filter(item => item.aggregatedate.slice(0, l) === label)
+          .reduce((sum, item) => sum + item.deposits, 0)
+      );
+      withdrawals.push(
+        data
+          .filter(item => item.aggregatedate.slice(0, l) === label)
+          .reduce((sum, item) => sum + item.withdrawals, 0)
+      );
+    });
+
+    data = {
+      labels: Array.from(labels),
+      datasets: [
+        {
+          label: gettext("Deposits"),
+          data: deposits,
+          backgroundColor: "#227D7D",
+        },
+        {
+          label: gettext("Withdrawals"),
+          data: withdrawals,
+          backgroundColor: "#D13838",
+        },
+      ],
+    };
+
+    return data;
+  };
+
+  const container = document.getElementById("transactionsGraphContainer");
+  const graphcanvas = container.querySelector("#transactionsGraph");
+
+  const Groupings = {
+    day: gettext("daily"),
+    month: gettext("monthly"),
+    year: gettext("yearly"),
+  };
+  var buttonContainer = document.createElement("div");
+  buttonContainer.className = "transactionGraphGroupingContainer";
+  buttonContainer.onclick = function(event) {
+    event.stopPropagation();
+    event.preventDefault();
+    var buttons = buttonContainer.querySelectorAll("a.btn");
+    buttons.forEach(function(button) {
+      button.classList.remove("btn-primary");
+      button.classList.add("btn-secondary");
+    });
+    grouping = event.target.dataset.grouping;
+    chart.options.scales.x.time.unit = event.target.dataset.grouping;
+    chart.options.scales.x.time.round = event.target.dataset.grouping;
+    (chart.data = buildGroupedDataGraphData(data, grouping)), chart.update();
+    event.target.classList.remove("btn-secondary");
+    event.target.classList.add("btn-primary");
+  };
+  container.prepend(buttonContainer);
+  Object.entries(Groupings).forEach(([key, value]) => {
+    var btn = document.createElement("a");
+    btn.className = "btn btn-secondary mr-2 transactionGroupingButton";
+    btn.id = "transactionGraphGrouping_" + key;
+    btn.dataset.grouping = key;
+    btn.innerText = value;
+    buttonContainer.append(btn);
+  });
+
+  // default to showing grouped by month
+  container
+    .querySelector("#transactionGraphGrouping_month")
+    .classList.remove("btn-secondary");
+  container
+    .querySelector("#transactionGraphGrouping_month")
+    .classList.add("btn-primary");
+
+  // render the chart
+  chart = new Chart(graphcanvas, {
+    type: "bar",
+    data: buildGroupedDataGraphData(data, "month"),
+    options: {
+      borderWidth: 1,
+      scales: {
+        x: {
+          type: "time",
+          time: {
+            unit: "month",
+            round: "month",
+          },
+          stacked: true,
+        },
+      },
+    },
+  });
 }
 renderTransactionsGraph();


### PR DESCRIPTION
chartjs does not seem to have a way to automatically "group and sum" dataset.

Implement grouping and summing with javascript from the daily data.

(and few more test as I initially thought there was an error on the python side of things :)

This removes the "weekly" grouping (dates in js are a pain)