### PR TITLE
Clarify English wording of custom invoices on user.html.

### DIFF
--- a/www/templates/www/user.html
+++ b/www/templates/www/user.html
@@ -74,7 +74,7 @@
             {% else %}
               {% blocktrans with ref=subscription.reference_number cost=subscription.service.cost_string %}This service can be paid with reference number {{ ref }}
                 to bank account {{bank_iban}}. Service price is {{ cost }}.{% endblocktrans %}<br/>
-              {% blocktrans %}To pay this service multiple times, you can create a custom invoice.{% endblocktrans %}
+              {% blocktrans %}To pay this service multiple times using a single transaction (e.g. paying multiple months of service in one payment), you can create a custom invoice.{% endblocktrans %}
               <a href="{% url 'custominvoice' %}">{% trans 'Create and view custom invoices' %}</a>
             {% endif %}
           {% endif %}


### PR DESCRIPTION
Some users have been confused by the wording here, assuming that it means that custom invoices should be used for repeated payments, when their purpose is to allow paying multiple months of service in one invoice. This should hopefully clarify the wording a bit.

The Finnish version of this page is already more explicit about the purpose of custom invoices:

> Jos haluat maksaa palvelun useaan kertaan yhdellä tilisiirrolla, voit tehdä vapaamuotoisen laskun.