### PR TITLE
Always fetch the whole previous year and all of this year so far

### DIFF
--- a/www/static/www/graphs.js
+++ b/www/static/www/graphs.js
@@ -6,7 +6,7 @@ async function renderTransactionsGraph() {
   // one year back
   startDate.setFullYear(startDate.getFullYear() - 1);
   // january
-  startDate.setMonth(1);
+  startDate.setMonth(0);
   // and from the first day of the month
   startDate.setDate(1);
 

--- a/www/static/www/graphs.js
+++ b/www/static/www/graphs.js
@@ -1,10 +1,15 @@
 async function renderTransactionsGraph() {
-  // for now default to fetching data 1 year back from now
-  // this fetches the data aggregated per day
+  // for now default to fetching all of last years data and this year untill today
+
+  // today
   let startDate = new Date();
+  // one year back
   startDate.setFullYear(startDate.getFullYear() - 1);
+  // january
+  startDate.setMonth(1);
   // and from the first day of the month
   startDate.setDate(1);
+
   const queryParams = {
     date__gte: startDate.toISOString().slice(0, 10),
   };


### PR DESCRIPTION
Kinda ugly, but this shows better graph when using the "group by year".

It should really fetch the data again and use a longer timespan as grouping by year could easily show 10 years of data.