### PR TITLE
Fix loading of local settings.

### DIFF
--- a/drfx/settings.py
+++ b/drfx/settings.py
@@ -345,12 +345,6 @@ OAUTH2_PROVIDER = {
 # Import just to get in the translation context
 # from utils import businesslogic
 
-# Load non-default settings from settings_local.py if it exists
-try:
-    from .settings_local import *  # noqa
-except ImportError:
-    pass
-
 CONSTANCE_BACKEND = "constance.backends.database.DatabaseBackend"
 
 # Constance config - settings for the app that are editable in django admin
@@ -387,3 +381,9 @@ CONSTANCE_CONFIG = {
     # "ACCOUNT_BIC": (ACCOUNT_BIC, "BIC of the association's bank account"),
     # "ACCOUNT_NAME": (ACCOUNT_NAME, "Name of the association's bank account"),
 }
+
+# Load non-default settings from settings_local.py if it exists
+try:
+    from .settings_local import *  # noqa
+except ImportError:
+    pass


### PR DESCRIPTION
In drxf/settings.py move importing of local settings last thing that is done, this way any/all custom settings gets priority as they're loaded last.

Fixes: https://github.com/TampereHacklab/mulysa/issues/460

Signed-off-by: Sami Olmari <sami@olmari.fi>