### PR TITLE
Make it possible to create new user from django admin panel

### DIFF
--- a/users/admin.py
+++ b/users/admin.py
@@ -87,6 +87,44 @@ class CustomUserAdmin(UserAdmin):
             {"fields": ("birthday",) + readonly_fields + ("marked_for_deletion_on",)},
         ),
     )
+
+    add_fieldsets = (
+        (
+            "Data",
+            {
+                "classes": ("wide",),
+                "fields": (
+                    "email",
+                    "first_name",
+                    "last_name",
+                    "nick",
+                    "mxid",
+                    "language",
+                    "municipality",
+                    "is_active",
+                    "is_staff",
+                    "is_superuser",
+                    "phone",
+                    "bank_account",
+                    'password1',
+                    'password2',
+                ),
+            },
+        ),
+
+        (
+            "Dates",
+            {
+                "classes": ("wide",),
+                "fields": (
+                    "birthday",
+                ),
+
+            },
+        ),
+
+    )
+
     inlines = [ServiceSubscriptionInline]
 
     actions = ["mark_for_deletion_on", "mark_for_deletion_off"]


### PR DESCRIPTION
Django admin panel crashed error with null birthday, when tried to add new custom user. Adding all fields that are present on mylsa add user field it is now possible to add custom user trough django admin panel.

Is mylsa page still neede as it seems it is shown only to admin profiles?