### PR TITLE
fix: allow user in bank transaction to be blank in forms

### DIFF
--- a/users/models/bank_transaction.py
+++ b/users/models/bank_transaction.py
@@ -10,7 +10,7 @@ class BankTransaction(models.Model):
     """
 
     # User this transaction was made by, or null if unknown
-    user = models.ForeignKey("CustomUser", on_delete=models.SET_NULL, null=True)
+    user = models.ForeignKey("CustomUser", on_delete=models.SET_NULL, null=True, blank=True)
 
     # Unique archival reference number that all transactions have
     archival_reference = models.CharField(

--- a/users/models/bank_transaction.py
+++ b/users/models/bank_transaction.py
@@ -10,7 +10,9 @@ class BankTransaction(models.Model):
     """
 
     # User this transaction was made by, or null if unknown
-    user = models.ForeignKey("CustomUser", on_delete=models.SET_NULL, null=True, blank=True)
+    user = models.ForeignKey(
+        "CustomUser", on_delete=models.SET_NULL, null=True, blank=True
+    )
 
     # Unique archival reference number that all transactions have
     archival_reference = models.CharField(


### PR DESCRIPTION
User relation can be null but form validation doesn't allow for blank values. Allow blank values to make it possible to comment transactions without users.

closes #513