### PR TITLE
Remove members import. Fixes #118

### DIFF
--- a/www/forms.py
+++ b/www/forms.py
@@ -75,9 +75,8 @@ class FileImportForm(forms.Form):
     filetype = forms.ChoiceField(
         label="File type",
         choices=[
-            ("TITO", "Transactions (Nordea TITO)"),
-            ("M", "Members (csv)"),
             ("HOLVI", "Holvi (xls)"),
+            ("TITO", "Transactions (Nordea TITO)"),
         ],
     )
     file = forms.FileField()

--- a/www/views.py
+++ b/www/views.py
@@ -114,8 +114,6 @@ def dataimport(request):
         form = FileImportForm(request.POST, request.FILES)
         if form.is_valid():
             dataimport = DataImport()
-            if request.POST["filetype"] == "M":
-                report = dataimport.importmembers(request.FILES["file"])
             if request.POST["filetype"] == "TITO":
                 report = dataimport.import_tito(request.FILES["file"])
             if request.POST["filetype"] == "HOLVI":


### PR DESCRIPTION
The import is written to just get old tampere members imported for the first time. There is no real need for that format anymore and the code was not that great anyway. Just remove it completely.

Also makes the holvi import be the intially selected option as it is the most used import. 

And marks TITO import as deprecated (it only works for nordea Tito files and nordigen is much better for nordea anyway)