### PR TITLE
CI fix exit-code for makemessage diff, 

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ commands = pipenv run coverage run manage.py makemigrations --check
 deps=pipenv
 commands =
     pipenv run coverage run manage.py makemessages -l fi --no-obsolete
-    git diff -- '***.po' --ignore-matching-lines=POT-Creation-Date --exit-code
+    git --no-pager diff --exit-code -- '***.po' --ignore-matching-lines=POT-Creation-Date
 allowlist_externals=git
 
 [testenv:flake8]

--- a/users/locale/fi/LC_MESSAGES/django.po
+++ b/users/locale/fi/LC_MESSAGES/django.po
@@ -643,8 +643,8 @@ msgstr ""
 msgid ""
 "%(value)s is not a valid Matrix id. It must be in format @user:example.org"
 msgstr ""
-"%(value)s ei ole kelvollinen Matrix id. Sen tulee olla muodossa @käyttäjä:"
-"esimerkki.org"
+"%(value)s ei ole kelvollinen Matrix id. Sen tulee olla muodossa "
+"@käyttäjä:esimerkki.org"
 
 #: users/validators.py:23
 #, python-format

--- a/users/locale/fi/LC_MESSAGES/django.po
+++ b/users/locale/fi/LC_MESSAGES/django.po
@@ -643,8 +643,8 @@ msgstr ""
 msgid ""
 "%(value)s is not a valid Matrix id. It must be in format @user:example.org"
 msgstr ""
-"%(value)s ei ole kelvollinen Matrix id. Sen tulee olla muodossa "
-"@käyttäjä:esimerkki.org"
+"%(value)s ei ole kelvollinen Matrix id. Sen tulee olla muodossa @käyttäjä:"
+"esimerkki.org"
 
 #: users/validators.py:23
 #, python-format


### PR DESCRIPTION
also remove pager from the diff output

there is still a "problem" with this. tox runs the makemessages to see the diff and that changes your working directory which is not perfect..

and as different versions of makemessages and po editors seem to do linechanges differently we will have some noise in translations