### PR TITLE
Allow admin to send emails to non staff user

### DIFF
--- a/www/views.py
+++ b/www/views.py
@@ -292,7 +292,7 @@ def usersettings(request, id):
             "subscribable_services": subscribable_services,
             "unsubscribable_services": unsubscribable_services,
             "unclaimed_nfccards": unclaimed_nfccards,
-            "show_send_email": request.user.is_staff is True,
+            "show_send_email": request.user.is_staff,
             "has_matrix": len(config.MATRIX_ACCESS_TOKEN) > 0 and customuser.mxid is not None,
             "matrix_registration_url": config.MATRIX_ACCOUNT_CRETION_URL,
             "matrix_registration_help": config.MATRIX_ACCOUNT_CRETION_HELP

--- a/www/views.py
+++ b/www/views.py
@@ -292,7 +292,7 @@ def usersettings(request, id):
             "subscribable_services": subscribable_services,
             "unsubscribable_services": unsubscribable_services,
             "unclaimed_nfccards": unclaimed_nfccards,
-            "show_send_email": customuser.is_staff,
+            "show_send_email": request.user.is_staff is True,
             "has_matrix": len(config.MATRIX_ACCESS_TOKEN) > 0 and customuser.mxid is not None,
             "matrix_registration_url": config.MATRIX_ACCOUNT_CRETION_URL,
             "matrix_registration_help": config.MATRIX_ACCOUNT_CRETION_HELP
@@ -403,7 +403,7 @@ def usersettings_claim_nfc(request, id):
 
 
 @login_required
-@self_or_staff_member_required
+@staff_member_required
 def usersettings_send_mail(request, id):
     """
     Send e-mail to this user


### PR DESCRIPTION
Newly added feature to send emails to users via usersetting page allowed email sends only to other staff members. This PR fixes that so that staff member can send email to anyuser. It allso hides send email field from regular member as it is not practical to send email back to self.