### PR TITLE
Fix initialization with empty database

### DIFF
--- a/www/forms.py
+++ b/www/forms.py
@@ -66,7 +66,7 @@ class RegistrationServicesFrom(forms.Form):
         widget=forms.CheckboxSelectMultiple,
         required=True,
         label=_("Services"),
-        choices=build_service_choices(),
+        choices=build_service_choices,
         error_messages={"required": _("You must select at least one service")},
     )
 


### PR DESCRIPTION
Initialization (including the first migration) was failing because a DB access function was called too early.